### PR TITLE
Prod

### DIFF
--- a/EnerGymAPI/Infrastructure/Data/Migrations/20260428224649_ActualizacionModelos.Designer.cs
+++ b/EnerGymAPI/Infrastructure/Data/Migrations/20260428224649_ActualizacionModelos.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EnerGymAPI.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EnerGymAPI.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(EnerGymDbContext))]
-    partial class EnerGymDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428224649_ActualizacionModelos")]
+    partial class ActualizacionModelos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EnerGymAPI/Infrastructure/Data/Migrations/20260428224649_ActualizacionModelos.cs
+++ b/EnerGymAPI/Infrastructure/Data/Migrations/20260428224649_ActualizacionModelos.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace EnerGymAPI.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ActualizacionModelos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AddedDate",
+                table: "RefreshTokens");
+
+            // 1. Quitar la llave primaria
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_RefreshTokens",
+                table: "RefreshTokens");
+
+            // 2. Eliminar la columna Id entera
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "RefreshTokens");
+
+            // 3. Añadir la nueva columna Id de tipo uuid
+            migrationBuilder.AddColumn<Guid>(
+                name: "Id",
+                table: "RefreshTokens",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "gen_random_uuid()"); // Si tu versión de Postgres lo soporta, o 00000000-0000-0000-0000-000000000000 en su defecto
+
+            // 4. Volver a asignar la llave primaria a la nueva columna
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_RefreshTokens",
+                table: "RefreshTokens",
+                column: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Revertir el proceso (uuid a int identity)
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_RefreshTokens",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "RefreshTokens");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Id",
+                table: "RefreshTokens",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_RefreshTokens",
+                table: "RefreshTokens",
+                column: "Id");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AddedDate",
+                table: "RefreshTokens",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/EnerGymAPI/Program.cs
+++ b/EnerGymAPI/Program.cs
@@ -127,6 +127,9 @@ try
 
     app.MapControllers();
 
+    // Endpoint de bienvenida en la raíz para comprobar que la API está viva
+    app.MapGet("/", () => "¡La API de EnerGym está funcionando correctamente!");
+
     app.Run();
 }
 catch (Exception ex)


### PR DESCRIPTION
This pull request introduces significant changes to the `RefreshToken` model and its database migration, as well as a minor improvement to the API's usability. The main focus is on updating the primary key of the `RefreshTokens` table from an integer to a UUID, which enhances security and scalability. Additionally, the relationship between `Usuario` and `RefreshTokens` is improved, and a simple health check endpoint is added for easier API verification.

**Database model and migration updates:**

* Changed the primary key of the `RefreshTokens` table from an `int` to a `Guid` (UUID), including updating the migration to drop the old column, add the new UUID column with default value generation, and reassign the primary key. (`EnerGymAPI/Infrastructure/Data/Migrations/20260428224649_ActualizacionModelos.cs`, `EnerGymAPI/Infrastructure/Data/Migrations/EnerGymDbContextModelSnapshot.cs`) [[1]](diffhunk://#diff-5a0136fea9e318f587dd44a6856ffebfdcdb36e9d4db746ce1044f43b771b848R1-R77) [[2]](diffhunk://#diff-325822bac384157834557f4fc52b7e3c05b53e742063c0c5506379cb24ab1cf6L218-R220)
* Removed the `AddedDate` column from the `RefreshTokens` table, simplifying the model. (`EnerGymAPI/Infrastructure/Data/Migrations/20260428224649_ActualizacionModelos.cs`, `EnerGymAPI/Infrastructure/Data/Migrations/EnerGymDbContextModelSnapshot.cs`) [[1]](diffhunk://#diff-5a0136fea9e318f587dd44a6856ffebfdcdb36e9d4db746ce1044f43b771b848R1-R77) [[2]](diffhunk://#diff-325822bac384157834557f4fc52b7e3c05b53e742063c0c5506379cb24ab1cf6L218-R220)
* Updated the relationship between `Usuario` and `RefreshToken` entities to use a navigation property, allowing a user to have multiple refresh tokens. (`EnerGymAPI/Infrastructure/Data/Migrations/EnerGymDbContextModelSnapshot.cs`) [[1]](diffhunk://#diff-325822bac384157834557f4fc52b7e3c05b53e742063c0c5506379cb24ab1cf6L496-R491) [[2]](diffhunk://#diff-325822bac384157834557f4fc52b7e3c05b53e742063c0c5506379cb24ab1cf6R603-R604)

**API usability improvement:**

* Added a root endpoint (`/`) that returns a welcome message, making it easier to check if the API is running. (`EnerGymAPI/Program.cs`)