### PR TITLE
Correciones

### DIFF
--- a/EnerGymAPI/Application/DTO/Recetas/RecetaUpdateRequestDto.cs
+++ b/EnerGymAPI/Application/DTO/Recetas/RecetaUpdateRequestDto.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace EnerGymAPI.Application.DTO.Recetas
+{
+    public class RecetaUpdateRequestDto
+    {
+        public string? Nombre { get; set; }
+        public int? TiempoPreparacion { get; set; }
+        public string? Alergenos { get; set; }
+        public string? ImagenUrl { get; set; }
+        public string? Descripcion { get; set; }
+    }
+}

--- a/EnerGymAPI/Application/Services/RecetaService.cs
+++ b/EnerGymAPI/Application/Services/RecetaService.cs
@@ -83,6 +83,33 @@ namespace EnerGymAPI.Application.Services
             };
         }
 
+        public async Task<RecetaResponseDto> UpdateRecetaAsync(Guid id, RecetaUpdateRequestDto request)
+        {
+            var receta = await _context.Recetas.FindAsync(id);
+            if (receta == null) return null;
+
+            receta.Nombre = request.Nombre ?? receta.Nombre;
+            receta.TiempoPreparacion = request.TiempoPreparacion ?? receta.TiempoPreparacion;
+            receta.Alergenos = request.Alergenos ?? receta.Alergenos;
+            receta.ImagenUrl = request.ImagenUrl ?? receta.ImagenUrl;
+            receta.Descripcion = request.Descripcion ?? receta.Descripcion;
+
+            _context.Recetas.Update(receta);
+            await _context.SaveChangesAsync();
+
+            return new RecetaResponseDto
+            {
+                Id = receta.Id,
+                UsuarioId = receta.UsuarioId,
+                Nombre = receta.Nombre,
+                TiempoPreparacion = receta.TiempoPreparacion,
+                Alergenos = receta.Alergenos,
+                ImagenUrl = receta.ImagenUrl,
+                Descripcion = receta.Descripcion,
+                EsPredisenada = receta.EsPredisenada
+            };
+        }
+
         public async Task<bool> DeleteRecetaAsync(Guid id)
         {
             var receta = await _context.Recetas.FindAsync(id);

--- a/EnerGymAPI/Controllers/AuthController.cs
+++ b/EnerGymAPI/Controllers/AuthController.cs
@@ -4,8 +4,6 @@ using EnerGymAPI.Domain.Entities;
 using EnerGymAPI.Infrastructure.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using System.Threading.Tasks;
-using System;
 
 namespace EnerGymAPI.Controllers
 {

--- a/EnerGymAPI/Controllers/RecetaController.cs
+++ b/EnerGymAPI/Controllers/RecetaController.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using EnerGymAPI.Application.DTO.Recetas;
+﻿using EnerGymAPI.Application.DTO.Recetas;
 using EnerGymAPI.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -35,6 +32,7 @@ namespace EnerGymAPI.Controllers
             {
                 return NotFound();
             }
+
             return Ok(receta);
         }
 
@@ -45,6 +43,18 @@ namespace EnerGymAPI.Controllers
             return CreatedAtAction(nameof(GetReceta), new { id = nuevaReceta.Id }, nuevaReceta);
         }
 
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateReceta(Guid id, RecetaUpdateRequestDto request)
+        {
+            var recetaActualizada = await _recetaService.UpdateRecetaAsync(id, request);
+            if (recetaActualizada == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(recetaActualizada);
+        }
+
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteReceta(Guid id)
         {
@@ -53,6 +63,7 @@ namespace EnerGymAPI.Controllers
             {
                 return NotFound();
             }
+
             return NoContent();
         }
     }

--- a/EnerGymAPI/Core/Interfaces/IRecetaService.cs
+++ b/EnerGymAPI/Core/Interfaces/IRecetaService.cs
@@ -10,6 +10,7 @@ namespace EnerGymAPI.Core.Interfaces
         Task<IEnumerable<RecetaResponseDto>> GetRecetasAsync();
         Task<RecetaResponseDto> GetRecetaByIdAsync(Guid id);
         Task<RecetaResponseDto> CreateRecetaAsync(RecetaCreateRequestDto request);
+        Task<RecetaResponseDto> UpdateRecetaAsync(Guid id, RecetaUpdateRequestDto request);
         Task<bool> DeleteRecetaAsync(Guid id);
     }
 }


### PR DESCRIPTION
This pull request adds support for updating recipes ("recetas") in the API. The main changes include introducing a new DTO for update requests, implementing the update logic in the service layer, exposing a new HTTP PUT endpoint in the controller, and updating the service interface accordingly.

**Feature: Recipe Update Support**

* Added new DTO `RecetaUpdateRequestDto` for handling partial updates to recipes, with all properties set as nullable.
* Implemented `UpdateRecetaAsync` method in `RecetaService`, allowing updates to existing recipes by merging provided fields with current values.
* Added `UpdateReceta` HTTP PUT endpoint to `RecetaController`, which uses the new service method to update a recipe by ID and returns the updated recipe or a 404 if not found.
* Updated the `IRecetaService` interface to include the new `UpdateRecetaAsync` method.

**Minor Code Cleanups**

* Removed unused `using` statements from `AuthController.cs` and `RecetaController.cs` for improved code clarity. [[1]](diffhunk://#diff-3c9ee478ee5d7bc6d50e0db1404349076e1d9b2fbc276999634911f1760994d3L7-L8) [[2]](diffhunk://#diff-d6c71539cb31d9b7d05caa7f5ad7f133ae43856d708ae715ecc8cffaf17bac2cL1-R1)